### PR TITLE
Add configuration for DepthAI RGB camera

### DIFF
--- a/videonode/config.yml
+++ b/videonode/config.yml
@@ -8,7 +8,7 @@ cameras:
     #parameters:
 
   - id: front
-    source: v4l2src /dev/video0
+    source: udpsrc port=5600
     #parameters:
 
   - id: rear


### PR DESCRIPTION
The DepthAI camera is configured to stream to the UDP port 5600.
FYI: @jnippula @ezzkoram @jlaitine 