### PR TITLE
Generate debian package version using GITHUB_RUN_NUMBER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,16 @@
-FROM ubuntu:20.04 as communication_link_builder
-# Setup timezone
-RUN echo 'Etc/UTC' > /etc/timezone \
-    && ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime \
-    && apt-get update && apt-get install -q -y tzdata \
-    && rm -rf /var/lib/apt/lists/*
-# Install ROS 2
-RUN apt-get update -y && apt-get install -y --no-install-recommends \
-    curl \
-    gnupg2 \
-    lsb-release \
-    && rm -rf /var/lib/apt/lists/*
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-RUN echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list
+FROM ros:foxy as communication_link_builder
+
+ARG BUILD_NUMBER
+ARG DISTRIBUTION
+ARG ARCHITECTURE
+
 # Install build dependencies
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    curl \
     build-essential \
     fakeroot \
     git-core \
     golang \
-    ros-foxy-ros-base \
     libgstreamer1.0-0 \
     libgstreamer-plugins-base1.0-dev \
     libgstreamer-plugins-bad1.0-dev \
@@ -35,7 +27,7 @@ WORKDIR /build
 COPY . .
 
 RUN cd packaging/ \
-    && ./package.sh
+    && ./package.sh ${BUILD_NUMBER} ${DISTRIBUTION} ${ARCHITECTURE}
 
 FROM scratch
 


### PR DESCRIPTION
Use GITHUB_RUN_NUMBER as build number of version string. Store also the git commit hash into changelog so that debian package has link to exact git commit of the source repository from which the binaries are built.
Also reduces the Dockerfile build time a bit by reducing the amount of "apt-get update" calls.
