### PR TITLE
RSTP sink element is in this package

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -2,5 +2,5 @@ Package: communication-link
 Version: VERSION
 Maintainer: Jari Nippula <jarix@ssrc.tii.ae>
 Architecture: amd64
-Depends:
+Depends: gstreamer1.0-rtsp
 Description: Communication link for drone cloud connection


### PR DESCRIPTION
RTSP sink element is needed in the videonode pipeline to connect
to RTSP server.